### PR TITLE
RakuDoc: remove duplicate alias

### DIFF
--- a/src/languages/rakudoc.js
+++ b/src/languages/rakudoc.js
@@ -17,7 +17,7 @@ export default function(hljs) {
 
   return {
     name: 'RakuDoc',
-    aliases: ['pod6','POD6', 'rakudoc'],
+    aliases: ['pod6', 'rakudoc'],
     keywords: RAKUDOC_KEYWORDS,
     contains: RAKUDOC_DEFAULT_CONTAINS
   };


### PR DESCRIPTION
all aliases should be lowercase, which makes those two duplicates

Feedback from the review of https://github.com/highlightjs/highlight.js/pull/4166