### PR TITLE
rakuregexe: remove aliases that conflicts with raku

### DIFF
--- a/src/languages/rakuregexe.js
+++ b/src/languages/rakuregexe.js
@@ -16,7 +16,7 @@ export default function(hljs) {
 
   return {
     name: 'RakuRegexe',
-    aliases: ['rakuregexe','Perl 6', 'p6', 'pm6', 'rakumod'],
+    aliases: ['rakuregexe'],
     keywords: RAKUREGEX_KEYWORDS,
     contains: RAKUREGEX_DEFAULT_CONTAINS
   };


### PR DESCRIPTION
Feedback from the review of https://github.com/highlightjs/highlight.js/pull/4166